### PR TITLE
[ADD] maraplus: _opt_delete_marked

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,3 +6,4 @@ Wrapper for :code:`marabunta` package, that adds some extra features:
 * :code:`--db-password-file` argument to read file from file instead of direct input. It is mutually exclusive to :code:`--db-password`.
 * :code:`install` option for :code:`addons` key can be used if only install is needed. :code:`upgrade` manages both install and upgrade of modules.
 * :code:`--extra-mig-files` can be used to combine extra migration files with main one. This can be useful, when you want to reuse common setup with different projects.
+* :code:`DEL->{some-option}` can be used to mark option deletion, when multiple YAML files are merged. This allows to be able to remove not needed options instead of just adding new.

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -68,6 +68,20 @@ migration:
           - stock
 """
 
+YAML_4 = """
+---
+migration:
+  versions:
+    - version: setup
+      operations:
+        pre:
+          - DEL->{echo 'pre-operation'}
+          - anthem songs.pre::main
+      addons:
+        install:
+          - DEL->{crm}
+"""
+
 # When YAML_1 is combined with YAML_2
 expected_yaml_dct_1 = {
     'migration': {
@@ -189,6 +203,43 @@ expected_yaml_dct_3 = {
         ]
     }
 }
+# When YAML_1 combined with YAML_4
+expected_yaml_dct_4 = {
+    'migration': {
+        'options': {
+            'install_command': 'odoo2',
+        },
+        'versions': [
+            {
+                'version': 'setup',
+                'operations': {
+                    'pre': [
+                        'anthem songs.pre::main',
+                    ],
+
+                },
+                'addons': {
+                    # Must be empty, because YAML_4 marks it for
+                    # deletion.
+                    'install': [],
+                    'upgrade': ['note'],
+                }
+            },
+            {
+                'version': '0.1.0',
+                'operations': {
+                    'post': [
+                        'echo \'post-operation\'',
+                    ],
+
+                },
+                'addons': {
+                    'install': ['web', 'contacts'],
+                }
+            },
+        ]
+    }
+}
 
 
 def test_01_merge_yaml():
@@ -214,3 +265,11 @@ def test_03_merge_yaml():
     y3 = StringIO(YAML_3)
     parser = YamlParser.parser_from_buffer(y1, y2, y3)
     assert parser.parsed == expected_yaml_dct_3
+
+
+def test_04_merge_yaml():
+    """Merge YAML_1 with YAML4."""
+    y1 = StringIO(YAML_1)
+    y2 = StringIO(YAML_4)
+    parser = YamlParser.parser_from_buffer(y1, y2)
+    assert parser.parsed == expected_yaml_dct_4


### PR DESCRIPTION
Added a way to mark some options to be deleted after multiple YAML are
merged.

For example:

install:
  - crm
  - mrp

If second YAML adds:

install:
  - DEL->{mrp}

Final install list becomes:

install:
  - crm

[BRANCH] feature/options-replace