### PR TITLE
[ADD] maraplus: install_paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.venv

--- a/README.rst
+++ b/README.rst
@@ -16,4 +16,7 @@ Wrapper for :code:`marabunta` package, that adds some extra features:
 * If environment variable key is specified in configuration options, it will be
   replaced by its value, if such environment variable exists. E.g. if
   :code:`MY_ENV=test`, :code:`$MY_ENV` would be replaced by :code:`test`.
-
+* Can specify ``install_paths`` so modules are collected from specified file instead
+  of needing to explicitly specify in marabunta main yaml file. Modules specified in
+  these files are added into ``install`` option. If module already exists in ``install``
+  option, it is not added multiple times.

--- a/maraplus/config.py
+++ b/maraplus/config.py
@@ -53,8 +53,8 @@ class Config(config_orig.Config):
         """Override to create config with extra arguments."""
         if not (bool(args.db_password) ^ bool(args.db_password_file)):
             raise TypeError(
-                "--db-password and --db-password-file arguments are mutually" +
-                " exclusive"
+                "--db-password and --db-password-file arguments are mutually"
+                + " exclusive"
             )
         return cls(
             args.migration_file,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal=1
+[flake8]
+ignore = E203,W503
+max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license='AGPLv3+',
     packages=find_packages(),
     install_requires=[
-        'marabunta>=0.10.6',
+        'marabunta>=0.12.0',
         'mergedeep>=1.3.4',
         'PyYAML>=6.0',
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import pathlib
+import pytest
+
+
+@pytest.fixture(scope="package")
+def path_modules_one():
+    yield str(_get_path("modules_one.yml"))
+
+
+@pytest.fixture(scope="package")
+def path_modules_two():
+    yield str(_get_path("modules_two.yml"))
+
+
+def _get_path(*args) -> pathlib.Path:
+    p = pathlib.Path(__file__).parent / "data"
+    return p.joinpath(*args)

--- a/tests/data/modules_one.yml
+++ b/tests/data/modules_one.yml
@@ -1,0 +1,5 @@
+---
+install:
+  - crm
+  - sale
+  - mrp

--- a/tests/data/modules_two.yml
+++ b/tests/data/modules_two.yml
@@ -1,0 +1,5 @@
+---
+install:
+  - sale
+  - account
+  - stock

--- a/tests/test_install_path_addons.py
+++ b/tests/test_install_path_addons.py
@@ -1,0 +1,237 @@
+import io
+
+from maraplus.parser import YamlParser
+
+
+def test_01_parse_install_path_addons_with_install_key(path_modules_one):
+    # GIVEN
+    buffer = io.StringIO(f"""---
+migration:
+  options:
+    install_command: odoo
+  versions:
+    - version: setup
+      modes:
+        stage:
+          addons:
+            install: []
+      addons:
+        install:
+          - crm
+        install_paths:
+          - {path_modules_one}
+""")
+    # WHEN
+    res = YamlParser.parser_from_buffer(buffer).parsed
+    # THEN
+    assert res == {
+        'migration': {
+            'options': {'install_command': 'odoo'},
+            'versions': [
+                {
+                    'version': 'setup',
+                    'modes': {
+                        'stage': {
+                            'addons': {
+                                'install': [],
+                            }
+                        }
+                    },
+                    'addons': {
+                        'install': [
+                            'crm',
+                            'sale',
+                            'mrp'
+                        ]
+                    }
+                }
+            ],
+        }
+    }
+
+
+def test_02_parse_install_path_addons_without_install_key(path_modules_one):
+    # GIVEN
+    buffer = io.StringIO(f"""---
+migration:
+  options:
+    install_command: odoo
+  versions:
+    - version: setup
+      modes:
+        stage:
+          addons:
+            install: []
+      addons:
+        install_paths:
+          - {path_modules_one}
+""")
+    # WHEN
+    res = YamlParser.parser_from_buffer(buffer).parsed
+    # THEN
+    assert res == {
+        'migration': {
+            'options': {'install_command': 'odoo'},
+            'versions': [
+                {
+                    'version': 'setup',
+                    'modes': {
+                        'stage': {
+                            'addons': {
+                                'install': [],
+                            }
+                        }
+                    },
+                    'addons': {
+                        'install': [
+                            'crm',
+                            'sale',
+                            'mrp'
+                        ]
+                    }
+                }
+            ],
+        }
+    }
+
+
+def test_03_parse_install_path_addons_multiple(path_modules_one, path_modules_two):
+    # GIVEN
+    buffer = io.StringIO(f"""---
+migration:
+  options:
+    install_command: odoo
+  versions:
+    - version: setup
+      addons:
+        install_paths:
+          - {path_modules_one}
+          - {path_modules_two}
+""")
+    # WHEN
+    res = YamlParser.parser_from_buffer(buffer).parsed
+    # THEN
+    assert res == {
+        'migration': {
+            'options': {'install_command': 'odoo'},
+            'versions': [
+                {
+                    'version': 'setup',
+                    'addons': {
+                        'install': [
+                            'crm',
+                            'sale',
+                            'mrp',
+                            'account',
+                            'stock',
+                        ]
+                    }
+                }
+            ],
+        }
+    }
+
+
+def test_04_parse_install_path_addons_in_mode(path_modules_one):
+    # GIVEN
+    buffer = io.StringIO(f"""---
+migration:
+  options:
+    install_command: odoo
+  versions:
+    - version: setup
+      modes:
+        stage:
+          addons:
+            install:
+              - crm
+            install_paths:
+              - {path_modules_one}
+""")
+    # WHEN
+    res = YamlParser.parser_from_buffer(buffer).parsed
+    # THEN
+    assert res == {
+        'migration': {
+            'options': {'install_command': 'odoo'},
+            'versions': [
+                {
+                    'version': 'setup',
+                    'modes': {
+                        'stage': {
+                            'addons': {
+                                'install': [
+                                    'crm',
+                                    'sale',
+                                    'mrp'
+                                ],
+                            }
+                        }
+                    },
+                }
+            ],
+        }
+    }
+
+
+def test_05_parse_install_path_addons_in_multi_mode(path_modules_one, path_modules_two):
+    # GIVEN
+    buffer = io.StringIO(f"""---
+migration:
+  options:
+    install_command: odoo
+  versions:
+    - version: setup
+      modes:
+        stage:
+          addons:
+            install_paths:
+              - {path_modules_one}
+        prod:
+          addons:
+            install_paths:
+              - {path_modules_two}
+      addons:
+        install_paths:
+          - {path_modules_one}
+""")
+    # WHEN
+    res = YamlParser.parser_from_buffer(buffer).parsed
+    # THEN
+    assert res == {
+        'migration': {
+            'options': {'install_command': 'odoo'},
+            'versions': [
+                {
+                    'version': 'setup',
+                    'modes': {
+                        'stage': {
+                            'addons': {
+                                'install': [
+                                    'crm',
+                                    'sale',
+                                    'mrp'
+                                ],
+                            }
+                        },
+                        'prod': {
+                            'addons': {
+                                'install': [
+                                    'sale',
+                                    'account',
+                                    'stock'
+                                ],
+                            }
+                        },
+                    },
+                    'addons': {
+                        'install': [
+                            'crm',
+                            'sale',
+                            'mrp',
+                        ]
+                    }
+                }
+            ],
+        }
+    }

--- a/tests/test_unpack_keys.py
+++ b/tests/test_unpack_keys.py
@@ -1,0 +1,48 @@
+from maraplus.parser import unpack_keys_from_nested_dict
+
+
+def test_01_unpack_keys_no_asterisk():
+    # GIVEN
+    data = {'a': {'b1': {'c': 1}, 'b2': {'c': 2}}}
+    keys_chain = ['a', 'b1', 'c']
+    # WHEN
+    res = unpack_keys_from_nested_dict(data, keys_chain)
+    # THEN
+    assert res == [['a', 'b1', 'c']]
+
+
+def test_02_unpack_keys_one_asterisk():
+    # GIVEN
+    data = {'a': {'b1': {'c': 1}, 'b2': {'c': 2}}}
+    keys_chain = ['a', '*', 'c']
+    # WHEN
+    res = unpack_keys_from_nested_dict(data, keys_chain)
+    # THEN
+    assert res == [['a', 'b1', 'c'], ['a', 'b2', 'c']]
+
+
+def test_03_unpack_keys_two_asterisks():
+    # GIVEN
+    data = {'a': {'b1': {'c': 1}, 'b2': {'c': 2}}}
+    data = {
+        'a': {
+            'b1': {
+                'c1': {'d': 1},
+                'c2': {'d': 2},
+            },
+            'b2': {
+                'c3': {'d': 3},
+                'c4': {'d': 4},
+            },
+        }
+    }
+    keys_chain = ['a', '*', '*', 'd']
+    # WHEN
+    res = unpack_keys_from_nested_dict(data, keys_chain)
+    # THEN
+    assert res == [
+        ['a', 'b1', 'c1', 'd'],
+        ['a', 'b1', 'c2', 'd'],
+        ['a', 'b2', 'c3', 'd'],
+        ['a', 'b2', 'c4', 'd'],
+    ]


### PR DESCRIPTION
Option to specify paths where modules to install are defined. This allows to reuse list of modules that can be installed between multiple environments.

[BRANCH] feature-install-paths-ala